### PR TITLE
Add `lastLedgerSequence` to `TransactionStatus`

### DIFF
--- a/proto/transaction_status.proto
+++ b/proto/transaction_status.proto
@@ -7,11 +7,14 @@ option java_outer_classname = "TransactionStatusProto";
 option java_package = "io.xpring.proto";
 
 // The status of a transaction on the XRP Ledger.
-// Next field: 3
+// Next field: 4
 message TransactionStatus {
   // The transaction status code.
   string transaction_status_code = 1;
 
   // Whether the transaction was validated.
   bool validated = 2;
+
+  // The lastLedgerSequence this transaction will be valid in.
+  uint32 lastLedgerSequence = 3;
 }

--- a/proto/transaction_status.proto
+++ b/proto/transaction_status.proto
@@ -16,5 +16,5 @@ message TransactionStatus {
   bool validated = 2;
 
   // The lastLedgerSequence this transaction will be valid in.
-  uint32 lastLedgerSequence = 3;
+  uint32 last_ledger_sequence = 3;
 }


### PR DESCRIPTION
This is needed to reliably determine transaction submission. 

This field is generally returned inside a `Transaction` object. I'm omitting the full `Transaction` hierarchy here to simplify the parsing in the middleware. The [official gRPC support in rippled](https://github.com/ripple/rippled/pull/3159) returns the full transaction object. 



